### PR TITLE
Avoid dynamic memory allocation for funciton03/function16 (master side only)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,21 @@
+cmake_minimum_required(VERSION 3.3)
+project(lightmodbus)
+
+add_library(
+    lightmodbus
+    "${PROJECT_SOURCE_DIR}/src/core.c"
+    "${PROJECT_SOURCE_DIR}/src/master.c"
+    "${PROJECT_SOURCE_DIR}/src/slave.c"
+    "${PROJECT_SOURCE_DIR}/src/master/mcoils.c"
+    "${PROJECT_SOURCE_DIR}/src/master/mdiscreteinputs.c"
+    "${PROJECT_SOURCE_DIR}/src/master/minputregisters.c"
+    "${PROJECT_SOURCE_DIR}/src/master/mregisters.c"
+    "${PROJECT_SOURCE_DIR}/src/slave/scoils.c"
+    "${PROJECT_SOURCE_DIR}/src/slave/sdiscreteinputs.c"
+    "${PROJECT_SOURCE_DIR}/src/slave/sinputregisters.c"
+    "${PROJECT_SOURCE_DIR}/src/slave/sregisters.c"
+)
+
+target_compile_definitions(lightmodbus PUBLIC LIGHTMODBUS_MASTER_REGISTERS=1)
+
+target_include_directories(lightmodbus PUBLIC include)

--- a/include/lightmodbus/core.h
+++ b/include/lightmodbus/core.h
@@ -17,6 +17,10 @@
 #define MODBUS_ERROR_OTHER 16 //Other reason function was exited (eg. bad function parameter)
 #define MODBUS_ERROR_FRAME 32 //Frame contained incorrect data, and exception could not be thrown (eg. bytes count != reg count * 2 in slave's response)
 
+#define MODBUS_MASTER_MAX_REQUEST_SIZE 64
+#define MODBUS_MASTER_MAX_RESPONSE_SIZE 64
+#define MODBUS_MASTER_MAX_DATA_COUNT 8
+
 //Types
 typedef struct
 {

--- a/include/lightmodbus/master/mtypes.h
+++ b/include/lightmodbus/master/mtypes.h
@@ -36,6 +36,8 @@ typedef struct
 	ModbusException exception; //Optional exception read
 	ModbusFrame request; //Formatted request for slave
 	ModbusFrame response; //Response from slave should be put here
+    union ModbusParser parser;
+    union ModbusParser requestParser;
 } ModbusMasterStatus; //Type containing master device configuration data
 
 #endif

--- a/include/lightmodbus/master/mtypes.h
+++ b/include/lightmodbus/master/mtypes.h
@@ -36,8 +36,8 @@ typedef struct
 	ModbusException exception; //Optional exception read
 	ModbusFrame request; //Formatted request for slave
 	ModbusFrame response; //Response from slave should be put here
-    union ModbusParser parser;
-    union ModbusParser requestParser;
+	union ModbusParser parser;
+	union ModbusParser requestParser;
 } ModbusMasterStatus; //Type containing master device configuration data
 
 #endif

--- a/src/master.c
+++ b/src/master.c
@@ -60,10 +60,10 @@ uint8_t modbusParseResponse( ModbusMasterStatus *status )
 	}
 
 	union ModbusParser *parser = &(status->parser); 
-	memcpy( parser, status->response.frame, status->response.length );
+	memcpy( parser->frame, status->response.frame, status->response.length );
 
 	union ModbusParser *requestParser = &(status->requestParser);
-	memcpy( requestParser,  status->request.frame, status->request.length );
+	memcpy( requestParser->frame,  status->request.frame, status->request.length );
 
 	//Check if frame is exception response
 	if ( parser->base.function & 128 )

--- a/src/master.c
+++ b/src/master.c
@@ -59,24 +59,11 @@ uint8_t modbusParseResponse( ModbusMasterStatus *status )
 		return MODBUS_ERROR_OTHER;
 	}
 
-	//Allocate memory for union and copy frame to it
-	union ModbusParser *parser = (union ModbusParser *) malloc( status->response.length );
-	if ( parser == NULL )
-	{
-		status->finished = 1;
-		return MODBUS_ERROR_ALLOC;
-	}
-	memcpy( parser->frame, status->response.frame, status->response.length );
+	union ModbusParser *parser = &(status->parser); 
+	memcpy( parser, status->response.frame, status->response.length );
 
-	//Allocate memory for request union and copy frame to it
-	union ModbusParser *requestParser = (union ModbusParser *) malloc( status->request.length );
-	if ( requestParser == NULL )
-	{
-		free( parser );
-		status->finished = 1;
-		return MODBUS_ERROR_ALLOC;
-	}
-	memcpy( requestParser->frame,  status->request.frame, status->request.length );
+	union ModbusParser *requestParser = &(status->requestParser);
+	memcpy( requestParser,  status->request.frame, status->request.length );
 
 	//Check if frame is exception response
 	if ( parser->base.function & 128 )
@@ -133,9 +120,6 @@ uint8_t modbusParseResponse( ModbusMasterStatus *status )
 		}
 	}
 
-	//Free used memory
-	free( parser );
-	free( requestParser );
 	status->finished = 1;
 
 	return err;
@@ -144,16 +128,23 @@ uint8_t modbusParseResponse( ModbusMasterStatus *status )
 uint8_t modbusMasterInit( ModbusMasterStatus *status )
 {
 	//Very basic init of master side
-	if ( ( status->request.frame = (uint8_t *) malloc( 8 ) ) == NULL )
+	if ( ( status->request.frame = (uint8_t *) malloc( MODBUS_MASTER_MAX_REQUEST_SIZE ) ) == NULL )
 	{
 		return MODBUS_ERROR_ALLOC;
 	}
 
 	status->request.length = 0;
 	status->response.length = 0;
-	if ( ( status->data = (ModbusData *) malloc( sizeof( ModbusData ) ) ) == NULL )
+	if ( ( status->data = (ModbusData *) malloc( MODBUS_MASTER_MAX_DATA_COUNT * sizeof( ModbusData ) ) ) == NULL )
 	{
 		free( status->request.frame );
+		return MODBUS_ERROR_ALLOC;
+	}
+
+	if ( ( status->response.frame = (uint8_t *) malloc( MODBUS_MASTER_MAX_RESPONSE_SIZE ) ) == NULL )
+	{
+		free( status->request.frame );
+		free( status->data );
 		return MODBUS_ERROR_ALLOC;
 	}
 
@@ -172,4 +163,5 @@ void modbusMasterEnd( ModbusMasterStatus *status )
 	//Free memory
 	free( status->request.frame );
 	free( status->data );
+	free( status->response.frame );
 }

--- a/src/master/mregisters.c
+++ b/src/master/mregisters.c
@@ -15,10 +15,8 @@ uint8_t modbusBuildRequest03( ModbusMasterStatus *status, uint8_t address, uint1
 	status->request.length = 0;
 	status->finished = 0;
 
-	//Reallocate memory for final frame
-	status->request.frame = (uint8_t *) realloc( status->request.frame, frameLength );
-	if ( status->request.frame == NULL )
-	{
+	//Avoid buffer overflow
+	if (MODBUS_MASTER_MAX_REQUEST_SIZE < frameLength) {
 		status->finished = 1;
 		return MODBUS_ERROR_ALLOC;
 	}
@@ -50,10 +48,8 @@ uint8_t modbusBuildRequest06( ModbusMasterStatus *status, uint8_t address, uint1
 	status->request.length = 0;
 	status->finished = 0;
 
-	//Reallocate memory for final frame
-	status->request.frame = (uint8_t *) realloc( status->request.frame, frameLength );
-	if ( status->request.frame == NULL )
-	{
+	//Avoid buffer overflow
+	if (MODBUS_MASTER_MAX_REQUEST_SIZE < frameLength) {
 		status->finished = 1;
 		return MODBUS_ERROR_ALLOC;
 	}
@@ -88,10 +84,8 @@ uint8_t modbusBuildRequest16( ModbusMasterStatus *status, uint8_t address, uint1
 
 	if ( registerCount > 123 ) return MODBUS_ERROR_OTHER;
 
-	//Reallocate memory for final frame
-	status->request.frame = (uint8_t *) realloc( status->request.frame, frameLength );
-	if ( status->request.frame == NULL )
-	{
+	//Avoid buffer overflow
+	if (MODBUS_MASTER_MAX_REQUEST_SIZE < frameLength) {
 		status->finished = 1;
 		return MODBUS_ERROR_ALLOC;
 	}
@@ -143,10 +137,8 @@ uint8_t modbusParseResponse03( ModbusMasterStatus *status, union ModbusParser *p
 		return MODBUS_ERROR_FRAME;
 	}
 
-	//Allocate memory for ModbusData structures array
-	status->data = (ModbusData *) realloc( status->data, ( parser->response03.byteCount >> 1 ) * sizeof( ModbusData ) );
-	if ( status->data == NULL )
-	{
+	// Avoid buffer overflow
+	if (MODBUS_MASTER_MAX_DATA_COUNT < parser->response03.byteCount >> 1){
 		status->finished = 1;
 		return MODBUS_ERROR_ALLOC;
 	}
@@ -198,13 +190,6 @@ uint8_t modbusParseResponse06( ModbusMasterStatus *status, union ModbusParser *p
 	parser->response06.reg = modbusSwapEndian( parser->response06.reg );
 	parser->response06.value = modbusSwapEndian( parser->response06.value );
 
-	//Set up new data table
-	status->data = (ModbusData *) realloc( status->data, sizeof( ModbusData ) );
-	if ( status->data == NULL )
-	{
-		status->finished = 1;
-		return MODBUS_ERROR_ALLOC;
-	}
 
 	status->data[0].address = parser->base.address;
 	status->data[0].dataType = holdingRegister;

--- a/test/test.c
+++ b/test/test.c
@@ -90,7 +90,7 @@ void Test( )
 
 	//Process response
 	printf( "Let master process response...\n" );
-	mstatus.response.frame = sstatus.response.frame;
+	memcpy(mstatus.response.frame, sstatus.response.frame, sstatus.response.length);
 	mstatus.response.length = sstatus.response.length;
 	MasterError = modbusParseResponse( &mstatus );
 


### PR DESCRIPTION
This is modification PR for our liblightmodbus fork.
 -Avoid dynamic memory allocation for each function03(Read multiple holding registers) and function16(Write multiple holding registers) 
 
Note that change was made on only master side and only for function03/function16.
Other functions for master side and all functions for slave side still use dynamic memory allocation(malloc(), realloc(), free()).

https://www.wrike.com/workspace.htm?acc=1794223#path=folder&id=818021821&c=tableview&vid=62302443&a=1794223&ot=825081758&so=16&bso=10&sd=0&f=&st=space-364052400